### PR TITLE
decorative svg

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,7 +37,7 @@
         class="h-[50px] w-[50px] lg:h-[100px] lg:w-[100px]"
         slot="image"
         xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
+        viewBox="0 0 24 24" aria-hidden="true"
       >
         <defs>
           <linearGradient id="0" x1="0" y1="0.51" x2="1" y2="0.49">


### PR DESCRIPTION
The SVG (graphic element) should be considered decorative because it does not add vital information to the page. Adding an aria-hidden attribute set to true will hide the SVG from screen readers